### PR TITLE
Added a parameter 'name' in settings to name publications

### DIFF
--- a/client/pagination.js
+++ b/client/pagination.js
@@ -15,6 +15,7 @@ class PaginationFactory {
     this.settings = new ReactiveDict();
     const settings = _.extend(
       {
+        name : collection._name,
         page: 1,
         perPage: 10,
         filters: {},
@@ -27,6 +28,9 @@ class PaginationFactory {
 
     if (!this.currentPage()) {
       this.currentPage(settings.page);
+    }
+    if (!this.name()) {
+      this.name(settings.name);
     }
 
     if (!this.perPage()) {
@@ -51,6 +55,7 @@ class PaginationFactory {
 
     Tracker.autorun(() => {
         const options = {
+
           fields: this.fields(),
           sort: this.sort(),
           skip: (this.currentPage() - 1) * this.perPage(),
@@ -60,7 +65,7 @@ class PaginationFactory {
         if (this.debug()) {
           console.log(
             'Pagination',
-            this.collection._name,
+            this.name(),
             'subscribe',
             JSON.stringify(this.filters()),
             JSON.stringify(options)
@@ -71,14 +76,14 @@ class PaginationFactory {
         this.settings.set('ready', false);
 
         const handle = Meteor.subscribe(
-          this.collection._name,
+                this.name(),
           this.filters(),
           options,
           () => {
               this.settings.set('ready', true);
           }
         );
-        
+
         this.subscriptionId = handle.subscriptionId;
     });
   }
@@ -99,6 +104,12 @@ class PaginationFactory {
       }
     }
     return this.settings.get('perPage');
+  }
+  name(name){
+    if (arguments.length === 1) {
+      this.settings.set('name', !_.isEmpty(name) ? name : {});
+    }
+    return this.settings.get('name');
   }
 
   filters(filters) {
@@ -163,7 +174,7 @@ class PaginationFactory {
     if (this.debug()) {
       console.log(
         'Pagination',
-        this.collection._name,
+        this.name(),
         'find',
         JSON.stringify(query),
         JSON.stringify(optionsFind)

--- a/server/pagination.js
+++ b/server/pagination.js
@@ -12,13 +12,17 @@ class PaginationFactory {
 
     const settings = _.extend(
       {
+        name : collection._name,
         filters: {},
         dynamic_filters() {
           return {};
         },
       },
+
+
       settingsIn || {}
     );
+    console.log(settings.name);
 
     if (typeof settings.filters !== 'object') {
       // eslint-disable-next-line max-len
@@ -34,7 +38,10 @@ class PaginationFactory {
   }
 
   publish(collection, settings) {
-    Meteor.publish(collection._name, function addPub(query = {}, optionsInput = {}) {
+    console.log(collection);
+    console.log(settings);
+
+    Meteor.publish(settings.name, function addPub(query = {}, optionsInput = {}) {
       check(query, Match.Optional(Object));
       check(optionsInput, Match.Optional(Object));
 
@@ -89,7 +96,7 @@ class PaginationFactory {
       if (options.debug) {
         console.log(
           'Pagination',
-          collection._name,
+          settings.name,
           'find',
           JSON.stringify(findQuery),
           JSON.stringify(options)

--- a/server/pagination.js
+++ b/server/pagination.js
@@ -22,7 +22,7 @@ class PaginationFactory {
 
       settingsIn || {}
     );
-    console.log(settings.name);
+   
 
     if (typeof settings.filters !== 'object') {
       // eslint-disable-next-line max-len
@@ -38,8 +38,7 @@ class PaginationFactory {
   }
 
   publish(collection, settings) {
-    console.log(collection);
-    console.log(settings);
+    
 
     Meteor.publish(settings.name, function addPub(query = {}, optionsInput = {}) {
       check(query, Match.Optional(Object));


### PR DESCRIPTION
Solved this [issue](https://github.com/Kurounin/Pagination/issues/30) : 

Added a parameter named -'name' to name the publications.

Sample: Server side code with reference to this [example](https://github.com/Kurounin/PaginationExample) : 

server.js
```
new Meteor.Pagination(MyCollection, {
    name : "pub",
    filters: {is_enabled: true}
});
```

```
new Meteor.Pagination(MyCollection, {
    name : "pubmet",
    filters: {is_enabled: false}
});
```

client.js
```
Template.hello2.onCreated(function helloOnCreated() {
    this.pagination = new Meteor.Pagination(MyCollection, {
        name : "pubmet",
        filters: {
            idx: {$gt: 9}
        },
        sort: {
            title: 1
        },
        debug: true
    });
});
```
```
Template.hello.onCreated(function helloOnCreated() {
    this.pagination = new Meteor.Pagination(MyCollection, {
        name : "pub",
        filters: {
            idx: {$gt: 9}
        },
        sort: {
            title: 1
        },
		debug: true
    });
});
```