### PR TITLE
Fix README transform_options example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ new Meteor.Pagination(MyCollection, {
         if (Roles.userIsInRole(this.userId, 'admin')) {
             fields.deleted = 1;
         }
-        return _.extend({fields}, options);
+        options.fields = _.extend(fields, options.fields);
+        return options;
     }
 });
 


### PR DESCRIPTION
A little change to the README to fix the transform_options example.
The parameter options is an object with nested objects and _.extend doesn't support deeply extension, so we need extend only the options.fields property.