### PR TITLE
Add skip functionality

### DIFF
--- a/client/pagination.js
+++ b/client/pagination.js
@@ -20,6 +20,7 @@ class PaginationFactory {
         perPage: 10,
         filters: {},
         fields: {},
+        skip: 0,
         sort: { _id: 1 },
         reactive: true,
         debug: false
@@ -45,6 +46,10 @@ class PaginationFactory {
       this.fields(settings.fields);
     }
 
+    if (!this.skip()) {
+      this.skip(settings.skip);
+    }
+
     if (!this.sort()) {
       this.sort(settings.sort);
     }
@@ -59,7 +64,7 @@ class PaginationFactory {
       const options = {
         fields: this.fields(),
         sort: this.sort(),
-        skip: (this.currentPage() - 1) * this.perPage(),
+        skip: (this.currentPage() - 1) * this.perPage() + this.skip(),
         limit: this.perPage(),
         reactive: settings.reactive
       };
@@ -181,6 +186,14 @@ class PaginationFactory {
     }
   }
 
+  skip(skip) {
+    if (arguments.length === 1) {
+      this.settings.set('skip', skip);
+    } else {
+      return this.settings.get('skip');
+    }
+  }
+
   sort(sort) {
     if (arguments.length === 1) {
       this.settings.set('sort', sort);
@@ -249,6 +262,7 @@ class PaginationFactory {
 
     this._checkObservers();
 
+    console.log(this.collection.find(query, optionsFind).fetch());
     return this.collection.find(query, optionsFind).fetch();
   }
 }

--- a/client/pagination.js
+++ b/client/pagination.js
@@ -262,7 +262,6 @@ class PaginationFactory {
 
     this._checkObservers();
 
-    console.log(this.collection.find(query, optionsFind).fetch());
     return this.collection.find(query, optionsFind).fetch();
   }
 }


### PR DESCRIPTION
This package is a dependency of the project I am currently working on. I use this package to paginate blog posts, and I wanted to implement "featured" post pinned to the top separately from the pagination. Given the way I implemented it, this would have required a skip option, but I noticed your package lacked such an option, hence my changes to the code.

Thank you for your time in considering this pull request.