### PR TITLE
Create a 'publishedCursor' function

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,28 +1,28 @@
 Package.describe({
   name: 'kurounin:pagination',
   summary: 'Meteor pagination done right. Usable in ReactJS or Blaze templates.',
-  version: '1.2.0',
+  version: '1.2.1',
   git: 'https://github.com/Kurounin/Pagination.git',
-  documentation: 'README.md',
-});
+  documentation: 'README.md'
+})
 
 Package.onUse((api) => {
-  api.versionsFrom('METEOR@1.2.1');
+  api.versionsFrom('METEOR@1.2.1')
   api.use([
     'ecmascript',
     'meteor-base',
     'check',
     'underscore',
-    'mongo',
-  ]);
+    'mongo'
+  ])
 
-  api.mainModule('server/pagination.js', 'server');
+  api.mainModule('server/pagination.js', 'server')
 
   api.use([
     'tracker',
     'reactive-var',
-    'reactive-dict',
-  ], 'client');
+    'reactive-dict'
+  ], 'client')
 
-  api.mainModule('client/pagination.js', 'client');
-});
+  api.mainModule('client/pagination.js', 'client')
+})

--- a/server/pagination.js
+++ b/server/pagination.js
@@ -1,77 +1,77 @@
-import { _ } from 'meteor/underscore';
-import { Meteor } from 'meteor/meteor';
-import { check, Match } from 'meteor/check';
+import { _ } from 'meteor/underscore'
+import { Meteor } from 'meteor/meteor'
+import { check, Match } from 'meteor/check'
 
-const countCollectionName = 'pagination-counts';
+const countCollectionName = 'pagination-counts'
 
-export function publishPagination(collection, settingsIn) {
+export function publishPagination (collection, settingsIn) {
   const settings = _.extend(
     {
       name: collection._name,
       filters: {},
-      dynamic_filters() {
-        return {};
+      dynamic_filters () {
+        return {}
       },
-      countInterval: 10000,
+      countInterval: 10000
     },
     settingsIn || {}
-  );
+  )
 
   if (typeof settings.filters !== 'object') {
     // eslint-disable-next-line max-len
-    throw new Meteor.Error(4001, 'Invalid filters provided. Server side filters need to be an object!');
+    throw new Meteor.Error(4001, 'Invalid filters provided. Server side filters need to be an object!')
   }
 
   if (typeof settings.dynamic_filters !== 'function') {
     // eslint-disable-next-line max-len
-    throw new Meteor.Error(4002, 'Invalid dynamic filters provided. Server side dynamic filters needs to be a function!');
+    throw new Meteor.Error(4002, 'Invalid dynamic filters provided. Server side dynamic filters needs to be a function!')
   }
 
   if (settings.countInterval < 50) {
-    settings.countInterval = 50;
+    settings.countInterval = 50
   }
 
-  Meteor.publish(settings.name, function addPub(query = {}, optionsInput = {}) {
-    check(query, Match.Optional(Object));
-    check(optionsInput, Match.Optional(Object));
+  Meteor.publish(settings.name, function addPub (query = {}, optionsInput = {}) {
+    check(query, Match.Optional(Object))
+    check(optionsInput, Match.Optional(Object))
 
-    const self = this;
-    let options = optionsInput;
-    let findQuery = {};
-    let filters = [];
+    const self = this
+    let options = optionsInput
+    let findQuery = {}
+    let filters = []
 
     if (!_.isEmpty(query)) {
-      filters.push(query);
+      filters.push(query)
     }
 
     if (!_.isEmpty(settings.filters)) {
-      filters.push(settings.filters);
+      filters.push(settings.filters)
     }
 
-    const dynamic_filters = settings.dynamic_filters.call(self);
+    const dynamic_filters = settings.dynamic_filters.call(self)
 
     if (typeof dynamic_filters === 'object') {
       if (!_.isEmpty(dynamic_filters)) {
-        filters.push(dynamic_filters);
+        filters.push(dynamic_filters)
       }
     } else {
       // eslint-disable-next-line max-len
-      throw new Meteor.Error(4002, 'Invalid dynamic filters return type. Server side dynamic filters needs to be a function that returns an object!');
+      throw new Meteor.Error(4002, 'Invalid dynamic filters return type. Server side dynamic filters needs to be a function that returns an object!')
     }
 
     if (typeof settings.transform_filters === 'function') {
-      filters = settings.transform_filters.call(self, filters, options);
+      filters = settings.transform_filters.call(self, filters, options)
     }
 
     if (typeof settings.transform_options === 'function') {
-      options = settings.transform_options.call(self, filters, options);
+      options = settings.transform_options.call(self, filters, options)
     }
 
     if (filters.length > 0) {
       if (filters.length > 1) {
-        findQuery.$and = filters;
+        findQuery.$and = filters
       } else {
-        findQuery = filters[0];
+        findQuery = filters[0]
       }
     }
 
@@ -83,66 +83,71 @@ export function publishPagination(collection, settingsIn) {
         'publish',
         JSON.stringify(findQuery),
         JSON.stringify(options)
-      );
+      )
     }
 
     if (!options.reactive) {
-      const subscriptionId = `sub_${self._subscriptionId}`;
-      const count = collection.find(findQuery, {fields: {_id: 1}}).count();
-      const docs = collection.find(findQuery, options).fetch();
+      const subscriptionId = `sub_${self._subscriptionId}`
+      const count = collection.find(findQuery, { fields: { _id: 1 } }).count()
+      const docs = collection.find(findQuery, options).fetch()
 
-      self.added(countCollectionName, subscriptionId, {count: count});
+      self.added(countCollectionName, subscriptionId, { count: count })
 
-      _.each(docs, function(doc) {
-        self.added(collection._name, doc._id, doc);
+      _.each(docs, function (doc) {
+        self.added(collection._name, doc._id, doc)
 
-        self.changed(collection._name, doc._id, {[subscriptionId]: 1});
-      });
+        self.changed(collection._name, doc._id, { [subscriptionId]: 1 })
+      })
     } else {
-      const subscriptionId = `sub_${self._subscriptionId}`;
-      const countCursor = collection.find(findQuery, {fields: {_id: 1}});
+      const subscriptionId = `sub_${self._subscriptionId}`
+      const countCursor = collection.find(findQuery, { fields: { _id: 1 } })
 
-      self.added(countCollectionName, subscriptionId, {count: countCursor.count()});
+      self.added(countCollectionName, subscriptionId, { count: countCursor.count() })
 
-      const updateCount = _.throttle(Meteor.bindEnvironment(()=> {
-        self.changed(countCollectionName, subscriptionId, {count: countCursor.count()});
-      }), 50);
-      const countTimer = Meteor.setInterval(function() {
-        updateCount();
-      }, settings.countInterval);
-      const handle = collection.find(findQuery, options).observeChanges({
-        added(id, fields) {
-          self.added(collection._name, id, fields);
+      const updateCount = _.throttle(Meteor.bindEnvironment(() => {
+        self.changed(countCollectionName, subscriptionId, { count: countCursor.count() })
+      }), 50)
+      const countTimer = Meteor.setInterval(function () {
+        updateCount()
+      }, settings.countInterval)
+      const cursor = collection.find(findQuery, options)
+      const handle = cursor.observeChanges({
+        added (id, fields) {
+          self.added(collection._name, id, fields)
 
-          self.changed(collection._name, id, {[subscriptionId]: 1});
-          updateCount();
+          self.changed(collection._name, id, { [subscriptionId]: 1 })
+          updateCount()
         },
-        changed(id, fields) {
-          self.changed(collection._name, id, fields);
+        changed (id, fields) {
+          self.changed(collection._name, id, fields)
         },
-        removed(id) {
-          self.removed(collection._name, id);
-          updateCount();
+        removed (id) {
+          self.removed(collection._name, id)
+          updateCount()
         }
-      });
+      })
 
       self.onStop(() => {
-        Meteor.clearTimeout(countTimer);
-        handle.stop();
-      });
+        Meteor.clearTimeout(countTimer)
+        handle.stop()
+      })
+      if (typeof settings.publishedCursor === 'function') {
+        const moarcursors = settings.publishedCursor(cursor) || []
+        return moarcursors
+      }
     }
 
-    self.ready();
-  });
+    self.ready()
+  })
 }
 
 class PaginationFactory {
-  constructor(collection, settingsIn) {
+  constructor (collection, settingsIn) {
     // eslint-disable-next-line max-len
-    console.warn('Deprecated use of Meteor.Pagination. On server-side use publishPagination() function.');
+    console.warn('Deprecated use of Meteor.Pagination. On server-side use publishPagination() function.')
 
-    publishPagination(collection, settingsIn);
+    publishPagination(collection, settingsIn)
   }
 }
 
-Meteor.Pagination = PaginationFactory;
+Meteor.Pagination = PaginationFactory


### PR DESCRIPTION
Hi
I have an idea to improve your package, I just add a function to the object passed to publishPagination  named publishedCursor which is called with the cursor you use to observeChange. This allow me to publish some related cursor and avoid the creation of a second publication to publish that related stuff.

Here is an example of a pagination which publish some events and their category

```
publishPagination(Events, {
    filters: {},
    dynamic_filters () {
        return {};
    },
    transform_filters (filters) {
        return filters
    },
    transform_options (filters, options) {
        options.fields = {name: 1, category: 1}
        return options;
    },
    publishedCursor (cursor) {
      return [
        Categories.find({ _id: { $in: cursor.map(x => x.category) } }, { fields: { name: 1 } })
      ]
    }
});

```